### PR TITLE
Update Installing_on_Linux.md

### DIFF
--- a/wiki/Installing_on_Linux.md
+++ b/wiki/Installing_on_Linux.md
@@ -110,7 +110,7 @@ Install the stable PPA via the Command Line Interface (CLI):
     :   
         
 ```python
-        sudo apt install freecad freecad-doc
+        sudo apt install freecad freecad-common
         
 ```
         


### PR DESCRIPTION
Change step 3 of installation on linux to update the package from 'freecad-doc' to 'freecad-common' as it seem tha 'freecad-doc' has been removed.

When installing freecad on Ubuntu 20.04 from ppa I received this warning:
        """
        Package freecad-doc is not available, but is referred to by another package.
        This may mean that the package is missing, has been obsoleted, or
        is only available from another source
        However the following packages replace it:
          freecad-common
        
        E: Package 'freecad-doc' has no installation candidate
        """